### PR TITLE
postremove fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,8 @@ nfpms:
         dst: /lib/systemd/system/zerotier-systemd-manager.service
         type: "config"
     scripts:
-      postinstall: "postrun.sh"
-      postremove: "postrun.sh"
+      postinstall: "pkgsrc/postinstall.sh"
+      postremove: "pkgsrc/postremove.sh"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/pkgsrc/postinstall.sh
+++ b/pkgsrc/postinstall.sh
@@ -2,7 +2,7 @@
 
 set -xeu
 
-mv /var/run/zerotier-one.service /lib/systemd/system
+test -f /var/run/zerotier-one.service && mv /var/run/zerotier-one.service /lib/systemd/system
 systemctl daemon-reload
 systemctl enable zerotier-systemd-manager.timer
 systemctl start zerotier-systemd-manager.timer

--- a/pkgsrc/postremove.sh
+++ b/pkgsrc/postremove.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -xeu
+systemctl daemon-reload


### PR DESCRIPTION
postremovals of packages should now be more appropriate for the host,
before they were doing some really dumb stuff.

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>