### PR TITLE
PTR records, multiple DNS servers

### DIFF
--- a/template.network
+++ b/template.network
@@ -6,7 +6,9 @@ Name={{ .Interface }}
 [Network]
 Description={{ .NetworkName }}
 DHCP=no
-DNS={{ .DNS }}
+{{ range $key := .DNS -}}
+DNS={{ $key }}
+{{ end -}}
 Domains=~{{ .DNSSearch }}
 ConfigureWithoutCarrier=true
 KeepConfiguration=static


### PR DESCRIPTION
This brings support for resolvectl supporting PTR lookups through
zerotier networks, and mulitple DNS servers if Central specifies it

Signed-off-by: Erik Hollensbe <linux@hollensbe.org>