### PR TITLE
systemd units fixes

### DIFF
--- a/contrib/zerotier-systemd-manager.service
+++ b/contrib/zerotier-systemd-manager.service
@@ -1,10 +1,8 @@
 [Unit]
 Description=Update zerotier per-interface DNS settings
-Wants=zerotier-systemd-manager.timer zerotier-one.service
+Requires=zerotier-one.service
+After=zerotier-one.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/zerotier-systemd-manager
-
-[Install]
-WantedBy=multi-user.target

--- a/contrib/zerotier-systemd-manager.timer
+++ b/contrib/zerotier-systemd-manager.timer
@@ -2,7 +2,7 @@
 Description=Update zerotier per-interface DNS settings
 
 [Timer]
-OnStartupSec=2min
+OnStartupSec=1min
 OnUnitInactiveSec=1min
 
 [Install]

--- a/contrib/zerotier-systemd-manager.timer
+++ b/contrib/zerotier-systemd-manager.timer
@@ -1,12 +1,9 @@
 [Unit]
 Description=Update zerotier per-interface DNS settings
-Requires=zerotier-systemd-manager.service
 
 [Timer]
-Unit=zerotier-systemd-manager.service
-OnStartupSec=60
-OnUnitInactiveSec=60
-Persistent=true
+OnStartupSec=2min
+OnUnitInactiveSec=1min
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
I've redefined the systemd unit files to conform with "best practices":
1. Timer units shouldn't have dependencies.
2. .service unit run by a timer shouldn't be installable (it's supposed to run periodically, not as a service)
3. Persistent= directive is useful only with Realtime timer, not Monotonic, as used here.

More reading:
https://wiki.archlinux.org/title/Systemd/Timers#Examples